### PR TITLE
Feature/8 api skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ data_models.py → request/response models + LanceDB schema
 constants.py → paths, model names, configuration  
 middleware.py → logging and MLflow tracing
 
+### Running the backend
+
+Start the FastAPI server locally:
+
+```bash
+uv run uvicorn cookmate.backend.api:app --reload
+```
+
+The API will be available at `http://localhost:8000`. Interactive docs 
+are at `http://localhost:8000/docs`.
+
 ---
 
 #### frontend/

--- a/src/cookmate/backend/api.py
+++ b/src/cookmate/backend/api.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Cookmate AI=")
+
+@app.get("/health")
+def health():
+    return {"status": {"ok"}}


### PR DESCRIPTION
## Summary
Adds the FastAPI application skeleton with a health endpoint as the 
foundation for upcoming retrieval and LLM endpoints.

## Changes
- Created `src/cookmate/backend/api.py` with FastAPI app and health endpoint
- Updated README with instructions for running the backend locally

## How to verify
```bash
uv run uvicorn cookmate.backend.api:app --reload
```
Then visit `http://localhost:8000/health` and `http://localhost:8000/docs`.

Closes #8