### PR TITLE
Add Pydantic models for recipes request and response

### DIFF
--- a/src/cookmate/backend/data_models.py
+++ b/src/cookmate/backend/data_models.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+class Recipe(BaseModel):
+    title: str
+    steps: list[str]
+
+class RecipeResponse(BaseModel):
+    recipes: list[Recipe]
+
+class RecipeRequest(BaseModel):
+    ingredients: list[str]


### PR DESCRIPTION
## Summary
Adds Pydantic models defining the request/response contract for the 
upcoming `/recipes` endpoint.

## Changes
- `RecipeRequest` with `ingredients: list[str]`
- `Recipe` with `title: str` and `steps: list[str]`
- `RecipeResponse` with `recipes: list[Recipe]`

Closes #13 