### PR TITLE
Add Field descriptions to API models

### DIFF
--- a/src/cookmate/backend/data_models.py
+++ b/src/cookmate/backend/data_models.py
@@ -1,11 +1,31 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
 
 class Recipe(BaseModel):
-    title: str
-    steps: list[str]
+    title: str = Field(
+        description="The name of the recipe.",
+        examples=["Pasta with eggs"]
+    )
+    steps: list[str] = Field(
+        description="Ordered list of cooking instructions, one step per item.",
+        examples=[["Boil pasta", "Beat eggs", "Combine and serve"]]
+    )
+
 
 class RecipeResponse(BaseModel):
-    recipes: list[Recipe]
+    recipes: list[Recipe] = Field(
+        description="List of recommended recipes the user can make with their ingredients.",
+        examples=[[
+            {
+                "title": "Pasta with eggs",
+                "steps": ["Boil pasta", "Beat eggs", "Combine and serve"]
+            }
+        ]]
+    )
+
 
 class RecipeRequest(BaseModel):
-    ingredients: list[str]
+    ingredients: list[str] = Field(
+        description="List of ingredients the user has available at home.",
+        examples=[["eggs", "pasta", "tomato"]]
+    )


### PR DESCRIPTION
## Summary
Adds `Field` descriptions and examples to the API models. This will help PydanticAI 
generate better prompts when integrated later.

## Changes
- Added `Field` import from pydantic
- Added `description` and `examples` to all fields in:
  - `RecipeRequest.ingredients`
  - `Recipe.title` and `Recipe.steps`
  - `RecipeResponse.recipes`


The output should include descriptions and examples

Closes #18 