### PR TITLE
Add recipes endpoint returning sample data

### DIFF
--- a/src/cookmate/backend/api.py
+++ b/src/cookmate/backend/api.py
@@ -1,7 +1,32 @@
 from fastapi import FastAPI
 
+from cookmate.backend.data_models import RecipeRequest, RecipeResponse, Recipe
+
 app = FastAPI(title="Cookmate AI=")
 
 @app.get("/health")
 def health():
     return {"status": {"ok"}}
+
+@app.post("/recipes", response_model=RecipeResponse)
+def get_recipes(request: RecipeRequest) -> RecipeResponse:
+    return RecipeResponse(
+        recipes=[
+            Recipe(
+                title="Pasta with eggs",
+                steps=[
+                    "Boil pasta in salted water until al dente.",
+                    "Beat eggs in a bowl and season with salt and pepper.",
+                    "Drain pasta and immediately mix with eggs off the heat."
+                ]
+            ),
+            Recipe(
+                title="Tomato pasta",
+                steps=[
+                    "Boil pasta in salted water.",
+                    "Heat olive oil and add chopped tomatoes.",
+                    "Mix pasta with tomato sauce and serve."
+                ]
+            )
+        ]
+    )


### PR DESCRIPTION
## Add recipes endpoint stub returning sample data

Adds a `recipes` POST endpoint that accepts a `RecipeRequest` and 
returns a `RecipeResponse` with hardcoded sample recipes. Real retrieval 
and LLM logic will be added.

## Changes
- Added `POST /recipes` in `api.py` with `response_model=RecipeResponse`
- Imported `RecipeRequest`, `RecipeResponse`, `Recipe` models
- Returns 2 hardcoded recipes (ignores `request.ingredients` by design)

## How to verify
```bash
uv run uvicorn cookmate.backend.api:app --reload
```
Returns sample ingredients with 2 recipes; invalid input returns 422.

Closes #16 