### PR TITLE
Feature/22 recipe agent

### DIFF
--- a/src/cookmate/backend/agents.py
+++ b/src/cookmate/backend/agents.py
@@ -1,4 +1,14 @@
 from mlflow import load_prompt
+from sentence_transformers import SentenceTransformer
+import lancedb
+
+from cookmate.utils.config import DB_DIR
+
+
+_embedding_model = SentenceTransformer("all-MiniLM-L6-v2")
+_db = lancedb.connect(DB_DIR)
+_table = _db.open_table("recipes")
+
 
 def load_recipe_agent_prompt(version: int = 1) -> str:
     """
@@ -9,3 +19,19 @@ def load_recipe_agent_prompt(version: int = 1) -> str:
     prompt = load_prompt(f"prompts:/recipe_agent_system_prompt/{version}")
 
     return prompt.template
+
+
+def retrieve_recipes(query: str, top_k: int = 3) -> list[dict]:
+    """
+    Search the recipe vector database for the top-K most relevant recipes.
+
+    Args:
+        query: A free-text query string (e.g. "eggs pasta tomato").
+        top_k: Number of recipes to return.
+
+    Returns:
+        A list of recipe dicts, each with 'id' and 'text' fields.
+    """
+    query_vector = _embedding_model.encode(query).tolist()
+    results = _table.search(query_vector).limit(top_k).to_list()
+    return [{"id": r["id"], "text": r["text"]} for r in results]

--- a/src/cookmate/backend/agents.py
+++ b/src/cookmate/backend/agents.py
@@ -1,14 +1,32 @@
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import os
+
 from mlflow import load_prompt
 from sentence_transformers import SentenceTransformer
 import lancedb
+from pydantic_ai import Agent 
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
 
-from cookmate.utils.config import DB_DIR
-
+from cookmate.utils.config import DB_DIR, OPENROUTER_BASE_URL, LLM_MODEL
+from cookmate.backend.data_models import RecipeResponse
 
 _embedding_model = SentenceTransformer("all-MiniLM-L6-v2")
 _db = lancedb.connect(DB_DIR)
 _table = _db.open_table("recipes")
 
+_provider = OpenAIProvider(
+    base_url=OPENROUTER_BASE_URL,
+    api_key=os.getenv("OPENROUTER_API_KEY"),
+)
+
+_model = OpenAIModel(
+    LLM_MODEL,
+    provider=_provider,
+)
 
 def load_recipe_agent_prompt(version: int = 1) -> str:
     """
@@ -35,3 +53,11 @@ def retrieve_recipes(query: str, top_k: int = 3) -> list[dict]:
     query_vector = _embedding_model.encode(query).tolist()
     results = _table.search(query_vector).limit(top_k).to_list()
     return [{"id": r["id"], "text": r["text"]} for r in results]
+
+_system_prompt = load_recipe_agent_prompt(version=1)
+
+recipe_agent = Agent(
+    model=_model,
+    output_type=RecipeResponse,
+    system_prompt=_system_prompt,
+)

--- a/src/cookmate/backend/agents.py
+++ b/src/cookmate/backend/agents.py
@@ -12,7 +12,7 @@ from pydantic_ai.models.openai import OpenAIModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
 from cookmate.utils.config import DB_DIR, OPENROUTER_BASE_URL, LLM_MODEL
-from cookmate.backend.data_models import RecipeResponse
+from cookmate.backend.data_models import RecipeRequest, RecipeResponse
 
 _embedding_model = SentenceTransformer("all-MiniLM-L6-v2")
 _db = lancedb.connect(DB_DIR)
@@ -38,22 +38,6 @@ def load_recipe_agent_prompt(version: int = 1) -> str:
 
     return prompt.template
 
-
-def retrieve_recipes(query: str, top_k: int = 3) -> list[dict]:
-    """
-    Search the recipe vector database for the top-K most relevant recipes.
-
-    Args:
-        query: A free-text query string (e.g. "eggs pasta tomato").
-        top_k: Number of recipes to return.
-
-    Returns:
-        A list of recipe dicts, each with 'id' and 'text' fields.
-    """
-    query_vector = _embedding_model.encode(query).tolist()
-    results = _table.search(query_vector).limit(top_k).to_list()
-    return [{"id": r["id"], "text": r["text"]} for r in results]
-
 _system_prompt = load_recipe_agent_prompt(version=1)
 
 recipe_agent = Agent(
@@ -61,3 +45,43 @@ recipe_agent = Agent(
     output_type=RecipeResponse,
     system_prompt=_system_prompt,
 )
+
+
+@recipe_agent.tool_plain
+def retrieve_recipes(query: str, top_k: int = 3) -> str:
+    """
+    Search the recipe vector database for the top-K most relevant recipes
+    based on the user's ingredients.
+
+    Args:
+        query: A free-text query string of ingredients (e.g. "eggs pasta tomato").
+        top_k: Number of recipes to return.
+
+    Returns:
+        A formatted string containing the retrieved recipes, ready for the agent.
+    """
+    query_vector = _embedding_model.encode(query).tolist()
+    results = _table.search(query_vector).limit(top_k).to_list()
+
+    lines = []
+    for i, recipe in enumerate(results, start=1):
+        lines.append(f"[{i}] (id: {recipe['id']}) {recipe['text']}")
+    return "\n".join(lines)
+
+
+async def generate_recipes(request: RecipeRequest) -> RecipeResponse:
+    """
+    Generate recipe suggestions based on the user's available ingredients.
+
+    The agent will automatically call the retrieve_recipes tool when needed
+    to look up recipes from the vector database.
+
+    Args:
+        request: The user's ingredient list wrapped in a RecipeRequest.
+
+    Returns:
+        A RecipeResponse withh recommended recipes.
+    """
+    query = ", ".join(request.ingredients)
+    result = await recipe_agent.run(query)
+    return result.output

--- a/src/cookmate/backend/api.py
+++ b/src/cookmate/backend/api.py
@@ -1,32 +1,14 @@
 from fastapi import FastAPI
 
-from cookmate.backend.data_models import RecipeRequest, RecipeResponse, Recipe
+from cookmate.backend.agents import generate_recipes
+from cookmate.backend.data_models import RecipeRequest, RecipeResponse
 
-app = FastAPI(title="Cookmate AI=")
+app = FastAPI(title="Cookmate AI")
 
 @app.get("/health")
 def health():
-    return {"status": {"ok"}}
+    return {"status": "ok"}
 
 @app.post("/recipes", response_model=RecipeResponse)
-def get_recipes(request: RecipeRequest) -> RecipeResponse:
-    return RecipeResponse(
-        recipes=[
-            Recipe(
-                title="Pasta with eggs",
-                steps=[
-                    "Boil pasta in salted water until al dente.",
-                    "Beat eggs in a bowl and season with salt and pepper.",
-                    "Drain pasta and immediately mix with eggs off the heat."
-                ]
-            ),
-            Recipe(
-                title="Tomato pasta",
-                steps=[
-                    "Boil pasta in salted water.",
-                    "Heat olive oil and add chopped tomatoes.",
-                    "Mix pasta with tomato sauce and serve."
-                ]
-            )
-        ]
-    )
+async def get_recipes(request: RecipeRequest) -> RecipeResponse:
+    return await generate_recipes(request)

--- a/src/cookmate/utils/config.py
+++ b/src/cookmate/utils/config.py
@@ -13,3 +13,6 @@ RAW_DATA_FILE = RAW_DATA_DIR / "3A2M.csv"
 
 EVALUATION_DATASET_PATH = BASE_DIR / "src" / "cookmate" / "monitoring" / "evaluation_dataset.json"
 RECIPES_JSON_PATH = PROCESSED_DATA_DIR / "recipes_clean.json"
+# OpenRouter / LLM
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+LLM_MODEL = "openai/gpt-oss-20b:free"


### PR DESCRIPTION
## Implement RAG agent with retrieval and LLM

Replaces the sample data with a working rag. The agent 
retrieves recipes from LanceDB, uses the system prompt from MLflow, 
and calls the LLM via OpenRouter.

## Changes
- Added `retrieve_recipes` as a tool for the agent
- Set up PydanticAI agent with OpenRouter
- Moved `OPENROUTER_BASE_URL` and `LLM_MODEL` to `config.py`
- Added endpoint to call the agent

## How to verify
Run `uv run uvicorn cookmate.backend.api:app --reload`, then execute.

## Note
Uses the free model `openai/gpt-oss-20b:free`.  (Can be changed)

Closes #22